### PR TITLE
fix(scripts): fetch-kernel 解包改用相对归档路径，修复 Windows GNU tar 把盘符当远程主机

### DIFF
--- a/dsh-desktop/scripts/fetch-kernel.js
+++ b/dsh-desktop/scripts/fetch-kernel.js
@@ -46,6 +46,8 @@ function resolvePnpmEntry() {
     ];
     const command = process.platform === 'win32' ? 'where' : 'which';
     const located = capture(command, ['pnpm']).split(/\r?\n/)[0];
+    if (located === undefined || located === '')
+        throw new Error('PATH 中找不到 pnpm');
     const binDir = path.dirname(located.replace(/\.cmd$/i, ''));
     candidates.push(path.join(binDir, 'node_modules', 'pnpm', 'bin', 'pnpm.cjs'), path.join(binDir, '..', 'lib', 'node_modules', 'pnpm', 'bin', 'pnpm.cjs'));
     const entry = candidates.find((candidate) => fs.existsSync(candidate));
@@ -80,7 +82,9 @@ function main() {
     console.log(`fetch-kernel: 下载 ${url}`);
     run('curl', curlArgs, WORK);
     console.log('fetch-kernel: 解包');
-    const tarArgs = ['-xzf', tgzPath];
+    // 相对归档路径（cwd=WORK）：绝对路径 `D:\...` 会被 GNU tar 当远程 tape 主机，
+    // 与下方内核补丁 2 同款思路，BSD tar 与 GNU tar 均兼容。
+    const tarArgs = ['-xzf', `${tag}.tar.gz`];
     run('tar', tarArgs, WORK);
     const srcDir = fs.readdirSync(WORK).find((e) => e.startsWith('deepseek-harness-') && fs.statSync(path.join(WORK, e)).isDirectory());
     if (!srcDir)

--- a/dsh-desktop/scripts/fetch-kernel.ts
+++ b/dsh-desktop/scripts/fetch-kernel.ts
@@ -98,7 +98,9 @@ function main(): void {
   run('curl', curlArgs, WORK);
 
   console.log('fetch-kernel: 解包');
-  const tarArgs = ['-xzf', tgzPath];
+  // 相对归档路径（cwd=WORK）：绝对路径 `D:\...` 会被 GNU tar 当远程 tape 主机，
+  // 与下方内核补丁 2 同款思路，BSD tar 与 GNU tar 均兼容。
+  const tarArgs = ['-xzf', `${tag}.tar.gz`];
   run('tar', tarArgs, WORK);
   const srcDir = fs.readdirSync(WORK).find((e) => e.startsWith('deepseek-harness-') && fs.statSync(path.join(WORK, e)).isDirectory());
   if (!srcDir) throw new Error('解包后找不到源码目录');


### PR DESCRIPTION
## 目的

修复 `scripts/fetch-kernel.js` 在 Windows（Git Bash / GNU tar 优先于 PATH）下解包必挂的问题：解包命令把绝对路径 `D:\...\.tar.gz` 传给 `tar`，GNU tar 会把 `D:` 解释为远程 tape 主机名，直接报错退出：

```
tar (child): Cannot connect to D: resolve failed
gzip: stdin: unexpected end of file
fetch-kernel: 命令失败（2）: tar -xzf D:\...\dsh-v0.1.2-alpha.1.tar.gz
```

改用相对归档路径（`run('tar', ...)` 的 cwd 本就是 WORK），GNU tar 与 BSD tar 均兼容。CI 的 Windows runner 默认走 PowerShell + System32 bsdtar，因此 CI 测不出该问题；任何 Git Bash 环境的开发者执行 `fetch-kernel` 都会撞上。

## 架构与范围

仅构建工具脚本 `dsh-desktop/scripts/fetch-kernel.ts`（及其入库的编译产物 `.js`），不触及 L1/L2/L3、插件、配置、更新与发布链路。修法与本脚本给内核 `tarball.ts` 打的「补丁 2」（相对归档路径，兼容 Windows BSD tar 与 GNU tar）完全同款。附带把 `.js` 编译产物与 `.ts` 源码对齐（补上源码中已存在、产物中缺失的 pnpm 未找到守卫）。

## 风险与兼容

相对路径在两种 tar 实现下均为合法输入，对现有可工作的环境（PowerShell + bsdtar）为无行为变化；不涉及公开接口、用户数据与升级路径。

## 验证

- [x] Skill 推荐的最低验证级别已完成（V1 定向：tsc 全量编译通过；本机完整跑通 `node scripts/fetch-kernel.js`——下载、解包、pnpm install、build:official、双家族 pack 全链路成功，250 个 tarball 落位 `vendor/kernel/0.1.2-alpha.1/`，随后 `npm ci` + `npm test` 728 测 0 失败）
- [x] `git diff --check` 已通过
- [x] 没有无关文件、日志、凭据、用户数据或大范围行尾变化
- [x] UI 变化已提供截图或录屏（不适用：无 UI 变化）
- [x] 未验证项已明确列出（见下）

未验证项：System32 bsdtar 环境（CI 同款）未单独回归——相对路径对该场景为显然合法输入，风险极低。

## 配置与迁移

无。

## 回退方式

revert 该提交即可，无状态与数据影响。
