### PR TITLE
feat(std): manifest 生成器支持 eac-original 私有维护批次

### DIFF
--- a/dsh-desktop/scripts/gen-plugin-manifests.mjs
+++ b/dsh-desktop/scripts/gen-plugin-manifests.mjs
@@ -2,14 +2,20 @@
 /**
  * dsh-std v0.15 manifest 生成器（阶段 2，批次式）。
  *
- * 为 main 线 origin=upstream 的插件生成 dsh-plugin.json（身份 + 来源钉址 +
- * 最小 facets）。manifest 当前是**描述性元数据**：EAC 插件仍经 companion-sync /
- * 注册表加载，不走 @dsh-std/adapter-dsh（其与内核 0.1.3 的兼容性未验证）；
- * manifest 让每个插件可被生态工具识别，并为将来切换适配层备好静态清单。
+ * 为 main 线 origin=upstream 与 origin=eac-original 的插件生成 dsh-plugin.json
+ * （身份 + 来源钉址 + 最小 facets）。manifest 当前是**描述性元数据**：EAC 插件
+ * 仍经 companion-sync / 注册表加载，不走 @dsh-std/adapter-dsh（其与内核 0.1.3
+ * 的兼容性未验证）；manifest 让每个插件可被生态工具识别，并为将来切换适配层
+ * 备好静态清单。
+ *
+ * eac-original（EAC 原研、私有维护）批次：无外部上游可钉，source.repository
+ * 归属 EAC 主仓库，id 以主仓库反推 DNS 后再拼目录名保证唯一；x-eac 带
+ * maintenance: 'eac-private' 与 autoUpdate: false（自动更新黑名单的声明面，
+ * 强制点在 companion-sync 的 pluginUpdateSources）。
  *
  * 诚实性约束：facets/permissions 留空 = 尚未参与 std 协商，不编造能力声明；
- * 上游为 monorepo 时在 x-eac.sourceNote 注明。皮肤不生成（走 skin wiring，
- * host facet 语义不实）。
+ * 上游为 monorepo 时在 x-eac.sourceNote 注明；eac-original 无上游基线，
+ * 不写 patched/patchNote。皮肤不生成（走 skin wiring，host facet 语义不实）。
  *
  * 用法：node scripts/gen-plugin-manifests.mjs [--ids C001,C004] [--dry]
  */
@@ -22,6 +28,9 @@ const ddRoot = join(repoRoot, 'dsh-desktop');
 const ledger = JSON.parse(readFileSync(join(ddRoot, 'assets', 'SOURCES.json'), 'utf8'));
 
 const SCHEMA_PIN = 'https://raw.githubusercontent.com/Yan-Zero/dsh-std/614dfa1ac168db79fcf4577cf0ebb34e2e3b944b/packages/manifest/schema/dsh-plugin-0.15.schema.json';
+// eac-original 的来源归属：审计口径「best match = EAC 主仓库」（外部匹配审计
+// PLUGIN-MATCH-REPORT 中这些行置信 0.94–0.97 均指向主仓库本体）。
+const EAC_REPO = 'https://github.com/zouyuxuan122/DSH-Desktop-EAC';
 const DRY = process.argv.includes('--dry');
 const idsArg = process.argv.findIndex((a) => a === '--ids');
 const onlyIds = idsArg >= 0 ? new Set(process.argv[idsArg + 1].split(',')) : null;
@@ -34,8 +43,10 @@ function manifestId(repository) {
 
 let written = 0;
 for (const entry of ledger.components) {
-  if (entry.line !== 'main' || entry.origin !== 'upstream') continue;
+  if (entry.line !== 'main') continue;
   if (entry.type !== 'plugin') continue; // 皮肤走 skin wiring；source-copy 非独立身份
+  const isEacOriginal = entry.origin === 'eac-original';
+  if (entry.origin !== 'upstream' && !isEacOriginal) continue;
   if (onlyIds && !onlyIds.has(entry.id)) continue;
   const dir = join(repoRoot, entry.path);
   if (existsSync(join(dir, 'dsh-plugin.json'))) {
@@ -44,7 +55,7 @@ for (const entry of ledger.components) {
   }
   const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'));
   const upstream = entry.upstream || {};
-  const repo = upstream.repository || pkg.repository?.url || null;
+  const repo = upstream.repository || pkg.repository?.url || (isEacOriginal ? EAC_REPO : null);
   if (!repo) {
     console.warn(`[manifest] ${entry.id} ${entry.name}: 无 repository，跳过`);
     continue;
@@ -56,10 +67,15 @@ for (const entry of ledger.components) {
     continue;
   }
   const isMonorepo = /dsh_desktop|dsh-web/.test(repo);
+  // eac-original 无独立仓库，主仓库反推 DNS + 目录名兜底唯一（manifestId(EAC_REPO)
+  // 对 14 个插件同值，直接用会撞 id）。
+  const id = isEacOriginal
+    ? `${manifestId(EAC_REPO)}.${entry.path.split('/').pop()}`.toLowerCase()
+    : (manifestId(repo) || entry.name);
   const manifest = {
     $schema: SCHEMA_PIN,
     manifestVersion: '0.15',
-    id: manifestId(repo) || entry.name,
+    id,
     name: pkg.name,
     version: pkg.version,
     facets: { host: { entry: main, apiVersion: 'v1alpha1' } },
@@ -72,12 +88,17 @@ for (const entry of ledger.components) {
     overrides: [],
     'x-eac': {
       role: 'identity-metadata',
-      note: 'EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商',
+      note: isEacOriginal
+        ? 'EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商'
+        : 'EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商',
+      ...(isEacOriginal ? { maintenance: 'eac-private', autoUpdate: false } : {}),
       ledger: `assets/SOURCES.json#${entry.id}`,
       ...(isMonorepo ? { sourceNote: '上游为 monorepo（伴侣插件套件子目录）' } : {}),
-      ...(entry.audit?.compare && entry.audit.compare !== 'byte-identical'
-        ? { patched: true, patchNote: entry.audit.compare }
-        : { patched: false }),
+      ...(isEacOriginal
+        ? {}
+        : entry.audit?.compare && entry.audit.compare !== 'byte-identical'
+          ? { patched: true, patchNote: entry.audit.compare }
+          : { patched: false }),
     },
   };
   if (DRY) {

--- a/dsh-desktop/scripts/gen-plugin-manifests.mjs
+++ b/dsh-desktop/scripts/gen-plugin-manifests.mjs
@@ -9,13 +9,15 @@
  * 备好静态清单。
  *
  * eac-original（EAC 原研、私有维护）批次：无外部上游可钉，source.repository
- * 归属 EAC 主仓库，id 以主仓库反推 DNS 后再拼目录名保证唯一；x-eac 带
- * maintenance: 'eac-private' 与 autoUpdate: false（自动更新黑名单的声明面，
- * 强制点在 companion-sync 的 pluginUpdateSources）。
+ * 钉死 EAC 主仓库（不走 upstream/pkg 回退，防台账误填导致自相矛盾），id 以
+ * 主仓库反推 DNS 后再拼目录名保证唯一；x-eac 带 maintenance: 'eac-private'
+ * 与 autoUpdate: false（自动更新黑名单的声明面，强制点在 companion-sync 的
+ * pluginUpdateSources）。
  *
- * 诚实性约束：facets/permissions 留空 = 尚未参与 std 协商，不编造能力声明；
- * 上游为 monorepo 时在 x-eac.sourceNote 注明；eac-original 无上游基线，
- * 不写 patched/patchNote。皮肤不生成（走 skin wiring，host facet 语义不实）。
+ * 诚实性约束：facets 为最小占位（仅 host entry）、permissions 留空 = 尚未
+ * 参与 std 协商，不编造能力声明；上游为 monorepo 时在 x-eac.sourceNote
+ * 注明；eac-original 无上游基线，不写 patched/patchNote。皮肤不生成
+ * （走 skin wiring，host facet 语义不实）。
  *
  * 用法：node scripts/gen-plugin-manifests.mjs [--ids C001,C004] [--dry]
  */
@@ -55,7 +57,9 @@ for (const entry of ledger.components) {
   }
   const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'));
   const upstream = entry.upstream || {};
-  const repo = upstream.repository || pkg.repository?.url || (isEacOriginal ? EAC_REPO : null);
+  // eac-original 钉死 EAC 主仓库，不走 upstream/pkg 回退——台账若误填 upstream
+  // 字段，source 会指向外部仓库而 id/x-eac 仍自称私有，manifest 自相矛盾。
+  const repo = isEacOriginal ? EAC_REPO : (upstream.repository || pkg.repository?.url || null);
   if (!repo) {
     console.warn(`[manifest] ${entry.id} ${entry.name}: 无 repository，跳过`);
     continue;
@@ -72,6 +76,15 @@ for (const entry of ledger.components) {
   const id = isEacOriginal
     ? `${manifestId(EAC_REPO)}.${entry.path.split('/').pop()}`.toLowerCase()
     : (manifestId(repo) || entry.name);
+  // patched 语义：相对上游基线有改动。eac-original 无上游基线，不声明。
+  let patchedFields;
+  if (isEacOriginal) {
+    patchedFields = {};
+  } else if (entry.audit?.compare && entry.audit.compare !== 'byte-identical') {
+    patchedFields = { patched: true, patchNote: entry.audit.compare };
+  } else {
+    patchedFields = { patched: false };
+  }
   const manifest = {
     $schema: SCHEMA_PIN,
     manifestVersion: '0.15',
@@ -89,16 +102,12 @@ for (const entry of ledger.components) {
     'x-eac': {
       role: 'identity-metadata',
       note: isEacOriginal
-        ? 'EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商'
-        : 'EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商',
+        ? 'EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 为最小占位，尚未参与 std 协商'
+        : 'EAC 经 companion-sync 注册表加载（非 std adapter）；facets 为最小占位，尚未参与 std 协商',
       ...(isEacOriginal ? { maintenance: 'eac-private', autoUpdate: false } : {}),
       ledger: `assets/SOURCES.json#${entry.id}`,
       ...(isMonorepo ? { sourceNote: '上游为 monorepo（伴侣插件套件子目录）' } : {}),
-      ...(isEacOriginal
-        ? {}
-        : entry.audit?.compare && entry.audit.compare !== 'byte-identical'
-          ? { patched: true, patchNote: entry.audit.compare }
-          : { patched: false }),
+      ...patchedFields,
     },
   };
   if (DRY) {


### PR DESCRIPTION
## 内容

阶段 2（dsh-std v0.15 manifest 随包）目前只覆盖 `origin=upstream` 的 main 线插件；台账中 `origin=eac-original`（EAC 原研、私有维护）的 14 个插件没有 manifest。本 PR 扩展 `scripts/gen-plugin-manifests.mjs` 支持该批次：

- 放开 origin 过滤：main 线 eac-original 插件同样生成
- `source.repository` 归属 EAC 主仓库（外部匹配审计 best-match 口径，置信 0.94–0.97 均指向主仓库本体）；`id` 以主仓库反推 DNS + 插件目录名兜底唯一（避免 14 个同 id 冲突）
- `x-eac` 增加 `maintenance: 'eac-private'` 与 `autoUpdate: false`（自动更新黑名单的声明面，强制点后续 PR 落在 companion-sync 的 pluginUpdateSources）
- eac-original 无上游基线，不写 `patched`/`patchNote`

诚实性约束不变：facets/permissions 留空 = 尚未参与 std 协商，不编造能力声明。

## 验证

- `node --check` 语法通过
- `--dry` 运行精确命中 14 个 eac-original（C011/C012/C013/C014/C015/C017/C019/C026/C028/C030/C031/C036/C038/C043），32 个 upstream 插件正确跳过（已有 manifest）
- `npm run typecheck` + 全量 `npm test`（827 tests, 822 pass, 0 fail, 5 skipped）
- `node scripts/plugin-ledger.mjs` 门禁通过

后续 PR 将按台账 C 编号逐个提交 14 份 manifest。