### PR TITLE
feat(governance): 私有维护插件自动更新黑名单（台账驱动）

### DIFF
--- a/dsh-desktop/lib/desktop/companion-sync.ts
+++ b/dsh-desktop/lib/desktop/companion-sync.ts
@@ -275,6 +275,35 @@ export function companionPluginsForPlatform(platform: NodeJS.Platform = 'win32')
 }
 
 // ---------------------------------------------------------------------------
+// 私有维护插件（自动更新黑名单，SOURCES.json 台账驱动）：
+//
+// 台账 origin=eac-original 的 main 线插件由 EAC 私有维护（外部匹配审计的
+// best-match 即 EAC 主仓库本体），没有可钉的外部上游发版——自动更新要么把
+// EAC 适配冲掉，要么更新到无从校验的来源。黑名单在此生成，pluginUpdateSources
+// 是唯一漏斗：即使将来误把私有插件登记进 PLUGIN_UPDATE_SOURCES 也会被强制
+// 过滤（sidecar server.ts 的「检测」与「应用更新」两条路都经过它）。
+// ---------------------------------------------------------------------------
+
+let privateMaintainedCache: Set<string> | null = null;
+
+/** 台账 origin=eac-original 的 main 线插件包名集合（自动更新黑名单）。
+ *  读取失败从宽返回空集：台账缺失/损坏时不拦截任何既有更新源。 */
+export function privateMaintainedPluginNames(): Set<string> {
+  if (privateMaintainedCache) return privateMaintainedCache;
+  const names = new Set<string>();
+  try {
+    const ledger = JSON.parse(fs.readFileSync(path.join(APP_ROOT, 'assets', 'SOURCES.json'), 'utf8')) as {
+      components?: { line?: string; type?: string; origin?: string; name?: string }[];
+    };
+    for (const c of ledger.components || []) {
+      if (c.line === 'main' && c.type === 'plugin' && c.origin === 'eac-original' && c.name) names.add(c.name);
+    }
+  } catch { /* 从宽处理 */ }
+  privateMaintainedCache = names;
+  return names;
+}
+
+// ---------------------------------------------------------------------------
 // 内置插件上游更新源（V4.3，plugin-updater.js 消费）：
 //
 // 只登记「上游仍在 npm / GitHub 发布」的社区插件 —— 内置分发的副本可以
@@ -358,18 +387,25 @@ export function seedBundledPlugins(profileDir: string): { changed: boolean; bund
   return { changed, bundles: bundled };
 }
 
-/** 把内置插件表 + 更新源注册表合并成 plugin-updater 的 sources 输入。 */
+/** 把内置插件表 + 更新源注册表合并成 plugin-updater 的 sources 输入。
+ *  私有维护插件（台账 eac-original）在此强制过滤——这是更新源的唯一漏斗。 */
 export function pluginUpdateSources(): { id: string; name: string; assetsDir: string; update: { npm?: string; github?: string } }[] {
   const removed = removedPluginIds();
+  const privateNames = privateMaintainedPluginNames();
+  const blocked: string[] = [];
   const out: { id: string; name: string; assetsDir: string; update: { npm?: string; github?: string } }[] = [];
   for (const p of COMPANION_PLUGINS) {
     const update = PLUGIN_UPDATE_SOURCES[p.id];
     if (!update) continue;
     if (removed.has(p.id)) continue;
+    if (privateNames.has(p.name)) { blocked.push(p.id); continue; }
     const dirName = p.dir || (p.name.includes('/') ? p.name.split('/').pop() as string : p.name);
     const assetsDir = path.join(APP_ROOT, 'assets', 'plugins', dirName);
     if (!fs.existsSync(path.join(assetsDir, 'package.json'))) continue;
     out.push({ id: p.id, name: p.name, assetsDir, update });
+  }
+  if (blocked.length) {
+    console.warn('[plugin-update] 私有维护插件不参与自动更新，已从更新源过滤: ' + blocked.join(', '));
   }
   return out;
 }

--- a/dsh-desktop/lib/desktop/companion-sync.ts
+++ b/dsh-desktop/lib/desktop/companion-sync.ts
@@ -282,12 +282,20 @@ export function companionPluginsForPlatform(platform: NodeJS.Platform = 'win32')
 // EAC 适配冲掉，要么更新到无从校验的来源。黑名单在此生成，pluginUpdateSources
 // 是唯一漏斗：即使将来误把私有插件登记进 PLUGIN_UPDATE_SOURCES 也会被强制
 // 过滤（sidecar server.ts 的「检测」与「应用更新」两条路都经过它）。
+//
+// fail-open 取舍：台账不可读时黑名单为空、不过滤（见
+// privateMaintainedPluginNames）——该状态下上述「误登记也无效」的保证暂不
+// 成立。私有插件本就不在 PLUGIN_UPDATE_SOURCES 白名单里，过滤是纵深防御。
 // ---------------------------------------------------------------------------
 
 let privateMaintainedCache: Set<string> | null = null;
 
 /** 台账 origin=eac-original 的 main 线插件包名集合（自动更新黑名单）。
- *  读取失败从宽返回空集：台账缺失/损坏时不拦截任何既有更新源。 */
+ *
+ *  fail-open：台账缺失/损坏时返回空集、不过滤——此时本函数不是强制点，
+ *  「误登记 PLUGIN_UPDATE_SOURCES 也会被强制过滤」的保证暂不成立（私有插件
+ *  本就不在白名单里，过滤为纵深防御）。仅缓存成功读取的结果，失败不落缓存，
+ *  文件恢复后下次调用即生效。 */
 export function privateMaintainedPluginNames(): Set<string> {
   if (privateMaintainedCache) return privateMaintainedCache;
   const names = new Set<string>();
@@ -298,8 +306,10 @@ export function privateMaintainedPluginNames(): Set<string> {
     for (const c of ledger.components || []) {
       if (c.line === 'main' && c.type === 'plugin' && c.origin === 'eac-original' && c.name) names.add(c.name);
     }
-  } catch { /* 从宽处理 */ }
-  privateMaintainedCache = names;
+    privateMaintainedCache = names;
+  } catch (err) {
+    console.warn('[plugin-update] SOURCES.json 读取失败，自动更新黑名单未生效（fail-open）: ' + String((err as Error).message || err));
+  }
   return names;
 }
 

--- a/dsh-desktop/lib/desktop/plugin-ops.ts
+++ b/dsh-desktop/lib/desktop/plugin-ops.ts
@@ -25,6 +25,7 @@ const {
   removedPluginIds,
   saveRemovedPluginIds,
   builtinPluginSourceDir,
+  privateMaintainedPluginNames,
   readJsonFile,
   copyPluginPackage,
 } = require('./companion-sync') as {
@@ -32,6 +33,7 @@ const {
   removedPluginIds(): Set<string>;
   saveRemovedPluginIds(ids: Set<string>): void;
   builtinPluginSourceDir(dirName: string): string;
+  privateMaintainedPluginNames(): Set<string>;
   readJsonFile(file: string): Record<string, unknown> | null;
   copyPluginPackage(profileDir: string, src: string, name: string): void;
 };
@@ -120,12 +122,16 @@ export function pluginManagerCollect(): unknown[] {
     const m = JSON.parse(fs.readFileSync(path.join(desktopProfileDir(), 'package.json'), 'utf8'));
     bundles = (m && m.dsh && m.dsh.profile && Array.isArray(m.dsh.profile.bundles)) ? m.dsh.profile.bundles : [];
   } catch { /* 缺省空 */ }
+  // 私有维护（台账 eac-original）标记：台账存包名，行按配套插件 id 记。
+  const privateNames = privateMaintainedPluginNames();
+  const privateIds = new Set(COMPANION_PLUGINS.filter((p) => privateNames.has(p.name)).map((p) => p.id));
   return collectPluginRows(entries, {
     companion: COMPANION_PLUGINS.map((p) => ({ id: p.id, name: p.name })),
     coreIds: onboardingLogic.CORE_PLUGIN_IDS,
     removedIds: removedPluginIds(),
     describe: (name: string) => pluginManagerPackageDescription(name),
     bundles,
+    privateIds,
   });
 }
 

--- a/dsh-desktop/plugin-manager-state.ts
+++ b/dsh-desktop/plugin-manager-state.ts
@@ -38,6 +38,8 @@ const KERNEL_BUNDLE_IDS = new Set([
 interface PluginRow {
   id: string; name: string; description: string; enabled: boolean;
   toggleable: boolean; removable: boolean; removed: boolean; core: boolean;
+  /** EAC 私有维护（台账 eac-original）：不参与内置插件自动更新。 */
+  privateMaintained: boolean;
   group: 'companion' | 'other' | 'core';
 }
 
@@ -47,6 +49,8 @@ interface CollectCtx {
   removedIds?: Iterable<string>;
   describe?: (name: string) => string;
   bundles?: string[];
+  /** 私有维护插件 id 集合（行上打 privateMaintained 标记）。 */
+  privateIds?: Iterable<string>;
 }
 
 function collectPluginRows(entries: unknown[], ctx: CollectCtx = {}): PluginRow[] {
@@ -57,6 +61,7 @@ function collectPluginRows(entries: unknown[], ctx: CollectCtx = {}): PluginRow[
   const removedIds = new Set(ctx.removedIds || []);
   const describe = typeof ctx.describe === 'function' ? ctx.describe : () => '';
   const bundles = Array.isArray(ctx.bundles) ? ctx.bundles : [];
+  const privateIds = new Set(ctx.privateIds || []);
 
   const insertById = new Map<string, { name: string; disabled: boolean }>();
   const userById = new Map<string, { name: string; disabled: boolean; hasConfig: boolean }>();
@@ -102,6 +107,7 @@ function collectPluginRows(entries: unknown[], ctx: CollectCtx = {}): PluginRow[
       removable: group === 'companion' && !isCore && !isRemoved,
       removed: isRemoved,
       core: isCore,
+      privateMaintained: privateIds.has(id),
       group,
     });
   };

--- a/dsh-desktop/test/plugin-private-governance.test.ts
+++ b/dsh-desktop/test/plugin-private-governance.test.ts
@@ -1,0 +1,70 @@
+// 私有维护插件（台账 origin=eac-original）治理契约：
+//
+//  1) 黑名单从 SOURCES.json 台账正确生成 —— main 线 eac-original 的 14 个
+//     插件包名必须一个不差（多一个 = 误判私有；少一个 = 该私有插件仍可能
+//     被自动更新冲掉 EAC 适配）；
+//  2) pluginUpdateSources() 是更新源唯一漏斗 —— 即使将来有人把私有插件误
+//     登记进 PLUGIN_UPDATE_SOURCES，也必须被强制过滤（sidecar server.ts 的
+//     「检测」与「应用更新」两条路都经过它）；
+//  3) 管理页行带 privateMaintained 标记（设置页可见「私有维护」的数据面）。
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import companionSync from '../lib/desktop/companion-sync.js';
+import pluginManagerState from '../plugin-manager-state.js';
+
+const { COMPANION_PLUGINS, PLUGIN_UPDATE_SOURCES, privateMaintainedPluginNames, pluginUpdateSources } = companionSync;
+const { collectPluginRows } = pluginManagerState;
+
+const EXPECTED_PRIVATE_NAMES = new Set([
+  'dsh-dock-settings',
+  'dsh-eac-core-bridge',
+  'dsh-eac-locale-compat',
+  '@deepseek-ai/dsh-easy-setup',
+  'dsh-feature-toggles',
+  'dsh-file-drop-eac',
+  'dsh-font-custom',
+  'dsh-pet-settings',
+  'dsh-phone',
+  'dsh-plugin-shield',
+  'dsh-plugin-wizard',
+  'dsh-settings-scroll-fix',
+  '@deepseek-ai/dsh-skin-switch',
+  'dsh-viewport-lock',
+]);
+
+test('黑名单 = 台账 main 线 eac-original 插件包名，一个不差', () => {
+  const names = privateMaintainedPluginNames();
+  const missing = [...EXPECTED_PRIVATE_NAMES].filter((n) => !names.has(n));
+  const extra = [...names].filter((n) => !EXPECTED_PRIVATE_NAMES.has(n));
+  assert.deepEqual(missing, [], '台账判为 eac-original 但黑名单缺失的插件');
+  assert.deepEqual(extra, [], '黑名单里存在但台账不是 main 线 eac-original 的插件');
+});
+
+test('强制过滤：私有插件即使被误登记进 PLUGIN_UPDATE_SOURCES 也进不了更新源', () => {
+  const target = COMPANION_PLUGINS.find((p) => p.name === 'dsh-viewport-lock');
+  assert.ok(target, 'COMPANION_PLUGINS 里必须存在 dsh-viewport-lock（黑名单过滤按包名匹配）');
+  const leaked = pluginUpdateSources().filter((s) => s.id === target.id);
+  assert.deepEqual(leaked, [], '基线：私有插件不应天然出现在更新源');
+  PLUGIN_UPDATE_SOURCES[target.id] = { npm: 'dsh-viewport-lock' };
+  try {
+    const after = pluginUpdateSources().filter((s) => s.id === target.id);
+    assert.deepEqual(after, [], '误登记后仍必须被黑名单强制过滤——这是自动更新黑名单的强制点');
+  } finally {
+    delete PLUGIN_UPDATE_SOURCES[target.id];
+  }
+  const kept = pluginUpdateSources().filter((s) => s.id === 'picturereader');
+  assert.equal(kept.length, 1, '非私有插件的更新源不受黑名单影响');
+});
+
+test('管理页行带 privateMaintained 标记（数据面）', () => {
+  const rows = collectPluginRows([], {
+    companion: [
+      { id: 'viewport-lock', name: 'dsh-viewport-lock' },
+      { id: 'picturereader', name: 'picturereader' },
+    ],
+    privateIds: ['viewport-lock'],
+  }) as Array<{ id: string; privateMaintained: boolean }>;
+  assert.equal(rows.find((r) => r.id === 'viewport-lock')?.privateMaintained, true);
+  assert.equal(rows.find((r) => r.id === 'picturereader')?.privateMaintained, false);
+});

--- a/dsh-desktop/test/plugin-private-governance.test.ts
+++ b/dsh-desktop/test/plugin-private-governance.test.ts
@@ -42,6 +42,9 @@ test('黑名单 = 台账 main 线 eac-original 插件包名，一个不差', () 
 });
 
 test('强制过滤：私有插件即使被误登记进 PLUGIN_UPDATE_SOURCES 也进不了更新源', () => {
+  // 注意：本用例直接突变共享的 PLUGIN_UPDATE_SOURCES 单例并在 finally 还原，
+  // 依赖 node:test 默认串行执行；若本文件将来开启 concurrency，需改为子测试
+  // （test(t, { concurrency: 1 }) 或独立进程）隔离，否则会互相踩。
   const target = COMPANION_PLUGINS.find((p) => p.name === 'dsh-viewport-lock');
   assert.ok(target, 'COMPANION_PLUGINS 里必须存在 dsh-viewport-lock（黑名单过滤按包名匹配）');
   const leaked = pluginUpdateSources().filter((s) => s.id === target.id);


### PR DESCRIPTION
## 内容

配套 [PR #307](https://github.com/zouyuxuan122/DSH-Desktop-EAC/pull/307)（生成器支持 eac-original 批次）落地后，私有维护插件将陆续拥有 manifest；本 PR 补上黑名单的**强制点**：

- `SOURCES.json` 台账 `origin=eac-original` 的 main 线插件 = 自动更新黑名单：`privateMaintainedPluginNames()` 读取台账生成包名集合（台账缺失/损坏时从宽返回空集，不拦截既有更新源）
- `pluginUpdateSources()` 强制过滤黑名单——更新源唯一漏斗，sidecar `server.ts` 的「检测」（dsh:plugin-updates）与「应用更新」两条路都经过它：即使将来误把私有插件登记进 `PLUGIN_UPDATE_SOURCES` 也无效
- `pluginManagerCollect()` 行打 `privateMaintained` 标记（设置页插件管理的数据面可见「私有维护」）
- 治理闭环对齐：兼容无报错 → 优质插件可自动更新（维持白名单）；不可溯源/私有维护 → 黑名单不再接受自动更新（本 PR）

## 验证

- 新增契约测试 `test/plugin-private-governance.test.ts` 3/3 通过：黑名单 14 项一个不差；误登记 `PLUGIN_UPDATE_SOURCES` 必须被滤掉；行标记正反例
- 全量 `npm test`：830 tests, 825 pass, 0 fail, 5 skipped
- `npm run typecheck` + `node scripts/plugin-ledger.mjs` 门禁通过