### PR TITLE
feat(std): 为 14 个 eac-original 插件批量补齐 dsh-plugin.json（std v0.15）

### DIFF
--- a/dsh-desktop/assets/plugins/dsh-dock-settings/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-dock-settings/dsh-plugin.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Yan-Zero/dsh-std/614dfa1ac168db79fcf4577cf0ebb34e2e3b944b/packages/manifest/schema/dsh-plugin-0.15.schema.json",
+  "manifestVersion": "0.15",
+  "id": "io.github.zouyuxuan122.dsh-desktop-eac.dsh-dock-settings",
+  "name": "dsh-dock-settings",
+  "version": "0.1.0",
+  "facets": {
+    "host": {
+      "entry": "lib/host.js",
+      "apiVersion": "v1alpha1"
+    }
+  },
+  "requires": {
+    "contracts": []
+  },
+  "permissions": [],
+  "contributes": {
+    "commands": []
+  },
+  "subscriptions": [],
+  "license": "MIT",
+  "source": {
+    "repository": "https://github.com/zouyuxuan122/DSH-Desktop-EAC"
+  },
+  "overrides": [],
+  "x-eac": {
+    "role": "identity-metadata",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "maintenance": "eac-private",
+    "autoUpdate": false,
+    "ledger": "assets/SOURCES.json#C011"
+  }
+}

--- a/dsh-desktop/assets/plugins/dsh-dock-settings/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-dock-settings/dsh-plugin.json
@@ -25,7 +25,7 @@
   "overrides": [],
   "x-eac": {
     "role": "identity-metadata",
-    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 为最小占位，尚未参与 std 协商",
     "maintenance": "eac-private",
     "autoUpdate": false,
     "ledger": "assets/SOURCES.json#C011"

--- a/dsh-desktop/assets/plugins/dsh-eac-core-bridge/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-eac-core-bridge/dsh-plugin.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Yan-Zero/dsh-std/614dfa1ac168db79fcf4577cf0ebb34e2e3b944b/packages/manifest/schema/dsh-plugin-0.15.schema.json",
+  "manifestVersion": "0.15",
+  "id": "io.github.zouyuxuan122.dsh-desktop-eac.dsh-eac-core-bridge",
+  "name": "dsh-eac-core-bridge",
+  "version": "1.0.0",
+  "facets": {
+    "host": {
+      "entry": "index.js",
+      "apiVersion": "v1alpha1"
+    }
+  },
+  "requires": {
+    "contracts": []
+  },
+  "permissions": [],
+  "contributes": {
+    "commands": []
+  },
+  "subscriptions": [],
+  "license": "MIT",
+  "source": {
+    "repository": "https://github.com/zouyuxuan122/DSH-Desktop-EAC"
+  },
+  "overrides": [],
+  "x-eac": {
+    "role": "identity-metadata",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "maintenance": "eac-private",
+    "autoUpdate": false,
+    "ledger": "assets/SOURCES.json#C012"
+  }
+}

--- a/dsh-desktop/assets/plugins/dsh-eac-core-bridge/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-eac-core-bridge/dsh-plugin.json
@@ -25,7 +25,7 @@
   "overrides": [],
   "x-eac": {
     "role": "identity-metadata",
-    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 为最小占位，尚未参与 std 协商",
     "maintenance": "eac-private",
     "autoUpdate": false,
     "ledger": "assets/SOURCES.json#C012"

--- a/dsh-desktop/assets/plugins/dsh-eac-locale-compat/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-eac-locale-compat/dsh-plugin.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Yan-Zero/dsh-std/614dfa1ac168db79fcf4577cf0ebb34e2e3b944b/packages/manifest/schema/dsh-plugin-0.15.schema.json",
+  "manifestVersion": "0.15",
+  "id": "io.github.zouyuxuan122.dsh-desktop-eac.dsh-eac-locale-compat",
+  "name": "dsh-eac-locale-compat",
+  "version": "1.0.0",
+  "facets": {
+    "host": {
+      "entry": "lib/index.js",
+      "apiVersion": "v1alpha1"
+    }
+  },
+  "requires": {
+    "contracts": []
+  },
+  "permissions": [],
+  "contributes": {
+    "commands": []
+  },
+  "subscriptions": [],
+  "license": "MIT",
+  "source": {
+    "repository": "https://github.com/zouyuxuan122/DSH-Desktop-EAC"
+  },
+  "overrides": [],
+  "x-eac": {
+    "role": "identity-metadata",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "maintenance": "eac-private",
+    "autoUpdate": false,
+    "ledger": "assets/SOURCES.json#C013"
+  }
+}

--- a/dsh-desktop/assets/plugins/dsh-eac-locale-compat/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-eac-locale-compat/dsh-plugin.json
@@ -25,7 +25,7 @@
   "overrides": [],
   "x-eac": {
     "role": "identity-metadata",
-    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 为最小占位，尚未参与 std 协商",
     "maintenance": "eac-private",
     "autoUpdate": false,
     "ledger": "assets/SOURCES.json#C013"

--- a/dsh-desktop/assets/plugins/dsh-easy-setup/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-easy-setup/dsh-plugin.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Yan-Zero/dsh-std/614dfa1ac168db79fcf4577cf0ebb34e2e3b944b/packages/manifest/schema/dsh-plugin-0.15.schema.json",
+  "manifestVersion": "0.15",
+  "id": "io.github.zouyuxuan122.dsh-desktop-eac.dsh-easy-setup",
+  "name": "@deepseek-ai/dsh-easy-setup",
+  "version": "0.1.0",
+  "facets": {
+    "host": {
+      "entry": "lib/index.js",
+      "apiVersion": "v1alpha1"
+    }
+  },
+  "requires": {
+    "contracts": []
+  },
+  "permissions": [],
+  "contributes": {
+    "commands": []
+  },
+  "subscriptions": [],
+  "license": "MIT",
+  "source": {
+    "repository": "https://github.com/zouyuxuan122/DSH-Desktop-EAC"
+  },
+  "overrides": [],
+  "x-eac": {
+    "role": "identity-metadata",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "maintenance": "eac-private",
+    "autoUpdate": false,
+    "ledger": "assets/SOURCES.json#C014"
+  }
+}

--- a/dsh-desktop/assets/plugins/dsh-easy-setup/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-easy-setup/dsh-plugin.json
@@ -25,7 +25,7 @@
   "overrides": [],
   "x-eac": {
     "role": "identity-metadata",
-    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 为最小占位，尚未参与 std 协商",
     "maintenance": "eac-private",
     "autoUpdate": false,
     "ledger": "assets/SOURCES.json#C014"

--- a/dsh-desktop/assets/plugins/dsh-feature-toggles/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-feature-toggles/dsh-plugin.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Yan-Zero/dsh-std/614dfa1ac168db79fcf4577cf0ebb34e2e3b944b/packages/manifest/schema/dsh-plugin-0.15.schema.json",
+  "manifestVersion": "0.15",
+  "id": "io.github.zouyuxuan122.dsh-desktop-eac.dsh-feature-toggles",
+  "name": "dsh-feature-toggles",
+  "version": "0.1.1",
+  "facets": {
+    "host": {
+      "entry": "lib/index.js",
+      "apiVersion": "v1alpha1"
+    }
+  },
+  "requires": {
+    "contracts": []
+  },
+  "permissions": [],
+  "contributes": {
+    "commands": []
+  },
+  "subscriptions": [],
+  "license": "MIT",
+  "source": {
+    "repository": "https://github.com/zouyuxuan122/DSH-Desktop-EAC"
+  },
+  "overrides": [],
+  "x-eac": {
+    "role": "identity-metadata",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "maintenance": "eac-private",
+    "autoUpdate": false,
+    "ledger": "assets/SOURCES.json#C015"
+  }
+}

--- a/dsh-desktop/assets/plugins/dsh-feature-toggles/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-feature-toggles/dsh-plugin.json
@@ -25,7 +25,7 @@
   "overrides": [],
   "x-eac": {
     "role": "identity-metadata",
-    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 为最小占位，尚未参与 std 协商",
     "maintenance": "eac-private",
     "autoUpdate": false,
     "ledger": "assets/SOURCES.json#C015"

--- a/dsh-desktop/assets/plugins/dsh-file-drop-eac/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-file-drop-eac/dsh-plugin.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Yan-Zero/dsh-std/614dfa1ac168db79fcf4577cf0ebb34e2e3b944b/packages/manifest/schema/dsh-plugin-0.15.schema.json",
+  "manifestVersion": "0.15",
+  "id": "io.github.zouyuxuan122.dsh-desktop-eac.dsh-file-drop-eac",
+  "name": "dsh-file-drop-eac",
+  "version": "0.1.2",
+  "facets": {
+    "host": {
+      "entry": "lib/index.js",
+      "apiVersion": "v1alpha1"
+    }
+  },
+  "requires": {
+    "contracts": []
+  },
+  "permissions": [],
+  "contributes": {
+    "commands": []
+  },
+  "subscriptions": [],
+  "license": "MIT",
+  "source": {
+    "repository": "https://github.com/zouyuxuan122/DSH-Desktop-EAC"
+  },
+  "overrides": [],
+  "x-eac": {
+    "role": "identity-metadata",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "maintenance": "eac-private",
+    "autoUpdate": false,
+    "ledger": "assets/SOURCES.json#C017"
+  }
+}

--- a/dsh-desktop/assets/plugins/dsh-file-drop-eac/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-file-drop-eac/dsh-plugin.json
@@ -25,7 +25,7 @@
   "overrides": [],
   "x-eac": {
     "role": "identity-metadata",
-    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 为最小占位，尚未参与 std 协商",
     "maintenance": "eac-private",
     "autoUpdate": false,
     "ledger": "assets/SOURCES.json#C017"

--- a/dsh-desktop/assets/plugins/dsh-font-custom/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-font-custom/dsh-plugin.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Yan-Zero/dsh-std/614dfa1ac168db79fcf4577cf0ebb34e2e3b944b/packages/manifest/schema/dsh-plugin-0.15.schema.json",
+  "manifestVersion": "0.15",
+  "id": "io.github.zouyuxuan122.dsh-desktop-eac.dsh-font-custom",
+  "name": "dsh-font-custom",
+  "version": "0.1.0",
+  "facets": {
+    "host": {
+      "entry": "lib/index.js",
+      "apiVersion": "v1alpha1"
+    }
+  },
+  "requires": {
+    "contracts": []
+  },
+  "permissions": [],
+  "contributes": {
+    "commands": []
+  },
+  "subscriptions": [],
+  "license": "MIT",
+  "source": {
+    "repository": "https://github.com/zouyuxuan122/DSH-Desktop-EAC"
+  },
+  "overrides": [],
+  "x-eac": {
+    "role": "identity-metadata",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "maintenance": "eac-private",
+    "autoUpdate": false,
+    "ledger": "assets/SOURCES.json#C019"
+  }
+}

--- a/dsh-desktop/assets/plugins/dsh-font-custom/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-font-custom/dsh-plugin.json
@@ -25,7 +25,7 @@
   "overrides": [],
   "x-eac": {
     "role": "identity-metadata",
-    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 为最小占位，尚未参与 std 协商",
     "maintenance": "eac-private",
     "autoUpdate": false,
     "ledger": "assets/SOURCES.json#C019"

--- a/dsh-desktop/assets/plugins/dsh-pet-settings/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-pet-settings/dsh-plugin.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Yan-Zero/dsh-std/614dfa1ac168db79fcf4577cf0ebb34e2e3b944b/packages/manifest/schema/dsh-plugin-0.15.schema.json",
+  "manifestVersion": "0.15",
+  "id": "io.github.zouyuxuan122.dsh-desktop-eac.dsh-pet-settings",
+  "name": "dsh-pet-settings",
+  "version": "0.1.0",
+  "facets": {
+    "host": {
+      "entry": "lib/index.js",
+      "apiVersion": "v1alpha1"
+    }
+  },
+  "requires": {
+    "contracts": []
+  },
+  "permissions": [],
+  "contributes": {
+    "commands": []
+  },
+  "subscriptions": [],
+  "license": "MIT",
+  "source": {
+    "repository": "https://github.com/zouyuxuan122/DSH-Desktop-EAC"
+  },
+  "overrides": [],
+  "x-eac": {
+    "role": "identity-metadata",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "maintenance": "eac-private",
+    "autoUpdate": false,
+    "ledger": "assets/SOURCES.json#C026"
+  }
+}

--- a/dsh-desktop/assets/plugins/dsh-pet-settings/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-pet-settings/dsh-plugin.json
@@ -25,7 +25,7 @@
   "overrides": [],
   "x-eac": {
     "role": "identity-metadata",
-    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 为最小占位，尚未参与 std 协商",
     "maintenance": "eac-private",
     "autoUpdate": false,
     "ledger": "assets/SOURCES.json#C026"

--- a/dsh-desktop/assets/plugins/dsh-phone/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-phone/dsh-plugin.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Yan-Zero/dsh-std/614dfa1ac168db79fcf4577cf0ebb34e2e3b944b/packages/manifest/schema/dsh-plugin-0.15.schema.json",
+  "manifestVersion": "0.15",
+  "id": "io.github.zouyuxuan122.dsh-desktop-eac.dsh-phone",
+  "name": "dsh-phone",
+  "version": "0.1.0",
+  "facets": {
+    "host": {
+      "entry": "lib/index.js",
+      "apiVersion": "v1alpha1"
+    }
+  },
+  "requires": {
+    "contracts": []
+  },
+  "permissions": [],
+  "contributes": {
+    "commands": []
+  },
+  "subscriptions": [],
+  "license": "MIT",
+  "source": {
+    "repository": "https://github.com/zouyuxuan122/DSH-Desktop-EAC"
+  },
+  "overrides": [],
+  "x-eac": {
+    "role": "identity-metadata",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "maintenance": "eac-private",
+    "autoUpdate": false,
+    "ledger": "assets/SOURCES.json#C028"
+  }
+}

--- a/dsh-desktop/assets/plugins/dsh-phone/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-phone/dsh-plugin.json
@@ -25,7 +25,7 @@
   "overrides": [],
   "x-eac": {
     "role": "identity-metadata",
-    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 为最小占位，尚未参与 std 协商",
     "maintenance": "eac-private",
     "autoUpdate": false,
     "ledger": "assets/SOURCES.json#C028"

--- a/dsh-desktop/assets/plugins/dsh-plugin-shield/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-plugin-shield/dsh-plugin.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Yan-Zero/dsh-std/614dfa1ac168db79fcf4577cf0ebb34e2e3b944b/packages/manifest/schema/dsh-plugin-0.15.schema.json",
+  "manifestVersion": "0.15",
+  "id": "io.github.zouyuxuan122.dsh-desktop-eac.dsh-plugin-shield",
+  "name": "dsh-plugin-shield",
+  "version": "0.1.0",
+  "facets": {
+    "host": {
+      "entry": "lib/index.js",
+      "apiVersion": "v1alpha1"
+    }
+  },
+  "requires": {
+    "contracts": []
+  },
+  "permissions": [],
+  "contributes": {
+    "commands": []
+  },
+  "subscriptions": [],
+  "license": "MIT",
+  "source": {
+    "repository": "https://github.com/zouyuxuan122/DSH-Desktop-EAC"
+  },
+  "overrides": [],
+  "x-eac": {
+    "role": "identity-metadata",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "maintenance": "eac-private",
+    "autoUpdate": false,
+    "ledger": "assets/SOURCES.json#C030"
+  }
+}

--- a/dsh-desktop/assets/plugins/dsh-plugin-shield/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-plugin-shield/dsh-plugin.json
@@ -25,7 +25,7 @@
   "overrides": [],
   "x-eac": {
     "role": "identity-metadata",
-    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 为最小占位，尚未参与 std 协商",
     "maintenance": "eac-private",
     "autoUpdate": false,
     "ledger": "assets/SOURCES.json#C030"

--- a/dsh-desktop/assets/plugins/dsh-plugin-wizard/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-plugin-wizard/dsh-plugin.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Yan-Zero/dsh-std/614dfa1ac168db79fcf4577cf0ebb34e2e3b944b/packages/manifest/schema/dsh-plugin-0.15.schema.json",
+  "manifestVersion": "0.15",
+  "id": "io.github.zouyuxuan122.dsh-desktop-eac.dsh-plugin-wizard",
+  "name": "dsh-plugin-wizard",
+  "version": "0.1.0",
+  "facets": {
+    "host": {
+      "entry": "lib/index.js",
+      "apiVersion": "v1alpha1"
+    }
+  },
+  "requires": {
+    "contracts": []
+  },
+  "permissions": [],
+  "contributes": {
+    "commands": []
+  },
+  "subscriptions": [],
+  "license": "MIT",
+  "source": {
+    "repository": "https://github.com/zouyuxuan122/DSH-Desktop-EAC"
+  },
+  "overrides": [],
+  "x-eac": {
+    "role": "identity-metadata",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "maintenance": "eac-private",
+    "autoUpdate": false,
+    "ledger": "assets/SOURCES.json#C031"
+  }
+}

--- a/dsh-desktop/assets/plugins/dsh-plugin-wizard/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-plugin-wizard/dsh-plugin.json
@@ -25,7 +25,7 @@
   "overrides": [],
   "x-eac": {
     "role": "identity-metadata",
-    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 为最小占位，尚未参与 std 协商",
     "maintenance": "eac-private",
     "autoUpdate": false,
     "ledger": "assets/SOURCES.json#C031"

--- a/dsh-desktop/assets/plugins/dsh-settings-scroll-fix/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-settings-scroll-fix/dsh-plugin.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Yan-Zero/dsh-std/614dfa1ac168db79fcf4577cf0ebb34e2e3b944b/packages/manifest/schema/dsh-plugin-0.15.schema.json",
+  "manifestVersion": "0.15",
+  "id": "io.github.zouyuxuan122.dsh-desktop-eac.dsh-settings-scroll-fix",
+  "name": "dsh-settings-scroll-fix",
+  "version": "2.0.2",
+  "facets": {
+    "host": {
+      "entry": "lib/index.js",
+      "apiVersion": "v1alpha1"
+    }
+  },
+  "requires": {
+    "contracts": []
+  },
+  "permissions": [],
+  "contributes": {
+    "commands": []
+  },
+  "subscriptions": [],
+  "license": "MIT",
+  "source": {
+    "repository": "https://github.com/zouyuxuan122/DSH-Desktop-EAC"
+  },
+  "overrides": [],
+  "x-eac": {
+    "role": "identity-metadata",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "maintenance": "eac-private",
+    "autoUpdate": false,
+    "ledger": "assets/SOURCES.json#C036"
+  }
+}

--- a/dsh-desktop/assets/plugins/dsh-settings-scroll-fix/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-settings-scroll-fix/dsh-plugin.json
@@ -25,7 +25,7 @@
   "overrides": [],
   "x-eac": {
     "role": "identity-metadata",
-    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 为最小占位，尚未参与 std 协商",
     "maintenance": "eac-private",
     "autoUpdate": false,
     "ledger": "assets/SOURCES.json#C036"

--- a/dsh-desktop/assets/plugins/dsh-skin-switch/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-skin-switch/dsh-plugin.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Yan-Zero/dsh-std/614dfa1ac168db79fcf4577cf0ebb34e2e3b944b/packages/manifest/schema/dsh-plugin-0.15.schema.json",
+  "manifestVersion": "0.15",
+  "id": "io.github.zouyuxuan122.dsh-desktop-eac.dsh-skin-switch",
+  "name": "@deepseek-ai/dsh-skin-switch",
+  "version": "0.1.0",
+  "facets": {
+    "host": {
+      "entry": "lib/index.js",
+      "apiVersion": "v1alpha1"
+    }
+  },
+  "requires": {
+    "contracts": []
+  },
+  "permissions": [],
+  "contributes": {
+    "commands": []
+  },
+  "subscriptions": [],
+  "license": "MIT",
+  "source": {
+    "repository": "https://github.com/zouyuxuan122/DSH-Desktop-EAC"
+  },
+  "overrides": [],
+  "x-eac": {
+    "role": "identity-metadata",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "maintenance": "eac-private",
+    "autoUpdate": false,
+    "ledger": "assets/SOURCES.json#C038"
+  }
+}

--- a/dsh-desktop/assets/plugins/dsh-skin-switch/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-skin-switch/dsh-plugin.json
@@ -25,7 +25,7 @@
   "overrides": [],
   "x-eac": {
     "role": "identity-metadata",
-    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 为最小占位，尚未参与 std 协商",
     "maintenance": "eac-private",
     "autoUpdate": false,
     "ledger": "assets/SOURCES.json#C038"

--- a/dsh-desktop/assets/plugins/dsh-viewport-lock/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-viewport-lock/dsh-plugin.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Yan-Zero/dsh-std/614dfa1ac168db79fcf4577cf0ebb34e2e3b944b/packages/manifest/schema/dsh-plugin-0.15.schema.json",
+  "manifestVersion": "0.15",
+  "id": "io.github.zouyuxuan122.dsh-desktop-eac.dsh-viewport-lock",
+  "name": "dsh-viewport-lock",
+  "version": "1.0.1",
+  "facets": {
+    "host": {
+      "entry": "lib/index.js",
+      "apiVersion": "v1alpha1"
+    }
+  },
+  "requires": {
+    "contracts": []
+  },
+  "permissions": [],
+  "contributes": {
+    "commands": []
+  },
+  "subscriptions": [],
+  "license": "MIT",
+  "source": {
+    "repository": "https://github.com/zouyuxuan122/DSH-Desktop-EAC"
+  },
+  "overrides": [],
+  "x-eac": {
+    "role": "identity-metadata",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "maintenance": "eac-private",
+    "autoUpdate": false,
+    "ledger": "assets/SOURCES.json#C043"
+  }
+}

--- a/dsh-desktop/assets/plugins/dsh-viewport-lock/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-viewport-lock/dsh-plugin.json
@@ -25,7 +25,7 @@
   "overrides": [],
   "x-eac": {
     "role": "identity-metadata",
-    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 为最小占位，尚未参与 std 协商",
     "maintenance": "eac-private",
     "autoUpdate": false,
     "ledger": "assets/SOURCES.json#C043"


### PR DESCRIPTION
按维护者反馈合并 #309–#322 为单个批量 PR（14 份 manifest，一个提交，全部由 #307 扩展版生成器产出）。

| 台账 | 插件 | 版本 | entry |
|---|---|---|---|
| C011 | dsh-dock-settings | 0.1.0 | lib/host.js |
| C012 | dsh-eac-core-bridge | 1.0.0 | index.js |
| C013 | dsh-eac-locale-compat | 1.0.0 | lib/index.js |
| C014 | @deepseek-ai/dsh-easy-setup | 0.1.0 | lib/index.js |
| C015 | dsh-feature-toggles | 0.1.1 | lib/index.js |
| C017 | dsh-file-drop-eac | 0.1.2 | lib/index.js |
| C019 | dsh-font-custom | 0.1.0 | lib/index.js |
| C026 | dsh-pet-settings | 0.1.0 | lib/index.js |
| C028 | dsh-phone | 0.1.0 | lib/index.js |
| C030 | dsh-plugin-shield | 0.1.0 | lib/index.js |
| C031 | dsh-plugin-wizard | 0.1.0 | lib/index.js |
| C036 | dsh-settings-scroll-fix | 2.0.2 | lib/index.js |
| C038 | @deepseek-ai/dsh-skin-switch | 0.1.0 | lib/index.js |
| C043 | dsh-viewport-lock | 1.0.1 | lib/index.js |

统一标记：x-eac.maintenance='eac-private'、autoUpdate:false（黑名单强制点见 #308）；id = io.github.zouyuxuan122.dsh-desktop-eac.<目录名>；不写 patched/patchNote。

诚实性约束：facets/permissions 留空 = 尚未参与 std 协商；描述性身份元数据，加载路径不变（companion-sync）。

验证：台账门禁 plugin-ledger.mjs 47/47 manifest 全过（含本批 14 份）；npm run typecheck 通过；注册表契约测试通过。

合入后 main 线 47/47 插件完成 std v0.15 建档（33 upstream + 14 eac-original）。